### PR TITLE
pass isDev into ingressControllerReady

### DIFF
--- a/pkg/install/condition.go
+++ b/pkg/install/condition.go
@@ -8,8 +8,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	consoleapi "github.com/openshift/console-operator/pkg/api"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/Azure/ARO-RP/pkg/env"
 )
 
 func (i *Installer) bootstrapConfigMapReady() (bool, error) {
@@ -61,10 +59,10 @@ func (i *Installer) clusterVersionReady() (bool, error) {
 	return false, nil
 }
 
-func (i *Installer) ingressControllerReady() (bool, error) {
+func (i *Installer) ingressControllerReady(isDev bool) (bool, error) {
 	ic, err := i.operatorcli.OperatorV1().IngressControllers("openshift-ingress-operator").Get("default", metav1.GetOptions{})
 	if err == nil && ic.Status.ObservedGeneration == ic.Generation {
-		if _, ok := i.env.(env.Dev); !ok {
+		if !isDev {
 			if ic.Spec.DefaultCertificate == nil {
 				return false, nil
 			}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -179,7 +179,10 @@ func (i *Installer) Install(ctx context.Context, installConfig *installconfig.In
 			action(i.disableOperatorHubSources),
 			action(i.updateRouterIP),
 			action(i.configureIngressCertificate),
-			condition{i.ingressControllerReady, 30 * time.Minute},
+			condition{func() (bool, error) {
+				_, isDev := i.env.(env.Dev)
+				return i.ingressControllerReady(isDev)
+			}, 30 * time.Minute},
 			action(i.finishInstallation),
 		},
 	}


### PR DESCRIPTION
I think mocking `env.Dev` might be more trouble than it's worth.

Here's an idea for making `ingressControllerReady` pass the unit test again.